### PR TITLE
Automapper License Addition

### DIFF
--- a/apps/identity-server/charts/identity-server/templates/identity-server-secrets.yaml
+++ b/apps/identity-server/charts/identity-server/templates/identity-server-secrets.yaml
@@ -18,6 +18,7 @@ spec:
         ProviderSettings__GoogleClientId: {{ `"{{ .google_clientid }}"` }}
         ProviderSettings__GoogleClientSecret: {{ `"{{ .google_secret }}"` }}
         Sendgrid__ApiKey: {{ `"{{ .sendgrid_apikey }}"` }}
+        Automapper__License: {{ `"{{ .automapper_license }}"` }}
         
   data:
   - secretKey: connectionstring
@@ -44,3 +45,7 @@ spec:
     remoteRef:
       key: secrets-k8/sendgrid
       property: apikey
+  - secretKey: automapper_license
+    remoteRef:
+      key: secrets-k8/automapper
+      property: licenseKey

--- a/apps/identity-server/charts/identity-server/templates/identity-server-secrets.yaml
+++ b/apps/identity-server/charts/identity-server/templates/identity-server-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: identity-server-secrets-es

--- a/environments/test/images.yaml
+++ b/environments/test/images.yaml
@@ -1,2 +1,2 @@
 imageTags:
-  identity_server: 1.4.2-platform-reference-change.5
+  identity_server: 1.4.3-july-25-upgrades.7


### PR DESCRIPTION
This pull request includes updates to the `identity-server` configuration and test environment to support new functionality and dependencies. The most significant changes include upgrading the `ExternalSecret` API version, adding a new secret for Automapper licensing, and updating the test environment image tag.

### Updates to `identity-server` secrets:

* Updated the `apiVersion` in `apps/identity-server/charts/identity-server/templates/identity-server-secrets.yaml` from `external-secrets.io/v1beta1` to `external-secrets.io/v1` for compatibility with the latest External Secrets Operator.
* Added a new secret, `Automapper__License`, to the `identity-server` configuration for managing the Automapper license key. [[1]](diffhunk://#diff-116ac5069d6202fbbb8e10b8dc2f19bf6dab0b31d19db6783227217bada5d932R21) [[2]](diffhunk://#diff-116ac5069d6202fbbb8e10b8dc2f19bf6dab0b31d19db6783227217bada5d932R48-R51)

### Test environment updates:

* Updated the `identity_server` image tag in `environments/test/images.yaml` to `1.4.3-july-25-upgrades.7` to reflect the latest build with the new changes.